### PR TITLE
Add test for most of Pandoc and implement parts of it

### DIFF
--- a/src/teodorlu/pandoc2hiccup.clj
+++ b/src/teodorlu/pandoc2hiccup.clj
@@ -55,6 +55,7 @@
 ;; See: https://hackage.haskell.org/package/pandoc-types-1.23.1/docs/Text-Pandoc-Definition.html#t:Block
 (defn pandoc-block->hiccup [{:keys [t c] :as block}]
   (case (keyword t)
+    :Plain (seq (wrap-inline [] c))
     :Para (wrap-inline [:p] c)
     :Header (pandoc-header->hiccup c)
     :BlockQuote (pandoc-blockquote->hiccup c)

--- a/src/teodorlu/pandoc2hiccup.clj
+++ b/src/teodorlu/pandoc2hiccup.clj
@@ -35,9 +35,6 @@
                                  :DoubleQuote ["“" "”"])]
               (concat [open] (wrap-inline () content) [close]))))
 
-(defn pandoc-para->hiccup [c]
-  (wrap-inline [:p] c))
-
 (defn pandoc-header->hiccup [[level attr inlines]]
   (let [attributes (pandoc-attr->hiccup attr)]
     (cond-> [(keyword (str "h" level))]
@@ -58,7 +55,7 @@
 ;; See: https://hackage.haskell.org/package/pandoc-types-1.23.1/docs/Text-Pandoc-Definition.html#t:Block
 (defn pandoc-block->hiccup [{:keys [t c] :as block}]
   (case (keyword t)
-    :Para (pandoc-para->hiccup c)
+    :Para (wrap-inline [:p] c)
     :Header (pandoc-header->hiccup c)
     :BlockQuote (pandoc-blockquote->hiccup c)
     :CodeBlock (pandoc-codeblock->hiccup c)))

--- a/src/teodorlu/pandoc2hiccup.clj
+++ b/src/teodorlu/pandoc2hiccup.clj
@@ -21,7 +21,7 @@
     :Str c
     :Emph (wrap-inline [:em] c)
     :Strong (wrap-inline [:strong] c)
-    :Strikeout (wrap-inline [:s] c)
+    :Strikeout (wrap-inline [:del] c)
     :Superscript (wrap-inline [:sup] c)
     :Subscript (wrap-inline [:sub] c)
     ;; Pandoc defaults to generating a span with the `smallcaps` class; this

--- a/src/teodorlu/pandoc2hiccup.clj
+++ b/src/teodorlu/pandoc2hiccup.clj
@@ -67,6 +67,9 @@
        (map (partial wrap-block [:li]))
        (into [:ol (pandoc-list-attr->hiccup list-attrs)])))
 
+(defn pandoc-bulletlist->hiccup [items]
+  (into [:ul] (map (partial wrap-block [:li]) items)))
+
 ;; See: https://hackage.haskell.org/package/pandoc-types-1.23.1/docs/Text-Pandoc-Definition.html#t:Block
 (defn pandoc-block->hiccup [{:keys [t c] :as block}]
   (prn block)
@@ -76,7 +79,8 @@
     :Header (pandoc-header->hiccup c)
     :BlockQuote (wrap-block [:blockquote] c)
     :CodeBlock (pandoc-codeblock->hiccup c)
-    :OrderedList (pandoc-orderedlist->hiccup c)))
+    :OrderedList (pandoc-orderedlist->hiccup c)
+    :BulletList (pandoc-bulletlist->hiccup c)))
 
 (defn pandoc->hiccup [{:keys [blocks]}]
   (map pandoc-block->hiccup blocks))

--- a/src/teodorlu/pandoc2hiccup.clj
+++ b/src/teodorlu/pandoc2hiccup.clj
@@ -1,12 +1,59 @@
 (ns teodorlu.pandoc2hiccup
   (:require [cheshire.core :as json]))
 
-(defn pandoc-block->hiccup [{:keys [t c]}]
-  (case t
-    "Space" " "
-    "Str" c
-    "Emph" (into [:em] (map pandoc-block->hiccup c))
-    "Para" (into [:p] (map pandoc-block->hiccup c))))
+(declare pandoc-block->hiccup)
+
+;; See: https://hackage.haskell.org/package/pandoc-types-1.23.1/docs/Text-Pandoc-Definition.html#t:Attr
+(defn pandoc-attr->hiccup [[id classes keyvals]]
+  (cond-> (into {} keyvals)
+    (not (empty? id)) (assoc :id id)
+    (not (empty? classes)) (assoc :class classes)))
+
+
+;; See: https://hackage.haskell.org/package/pandoc-types-1.23.1/docs/Text-Pandoc-Definition.html#t:Inline
+(defn pandoc-inline->hiccup [{:keys [t c]}]
+  (case (keyword t)
+    :Space " "
+    :Str c
+    :Emph (into [:em] (map pandoc-inline->hiccup c))
+    :Strong (into [:strong] (map pandoc-inline->hiccup c))
+    :Strikeout (into [:s] (map pandoc-inline->hiccup c))
+    :Superscript (into [:sup] (map pandoc-inline->hiccup c))
+    :Subscript (into [:sub] (map pandoc-inline->hiccup c))
+    ;; Pandoc defaults to generating a span with the `smallcaps` class; this
+    ;; however assumes the pandoc default css file to be included. I'm opting to
+    ;; inline this instead.
+    ;; See: https://pandoc.org/chunkedhtml-demo/8.12-inline-formatting.html#small-caps
+    :SmallCaps (into [:span {:style {:font-variant "small-caps"}}]
+                     (map pandoc-inline->hiccup c))))
+
+(defn pandoc-para->hiccup [c]
+  (into [:p] (map pandoc-inline->hiccup c)))
+
+(defn pandoc-header->hiccup [[level attr inlines]]
+  (let [attributes (pandoc-attr->hiccup attr)]
+    (cond-> [(keyword (str "h" level))]
+      (not (empty? attributes)) (conj attributes)
+      true (into (map pandoc-inline->hiccup inlines)))))
+
+(defn pandoc-blockquote->hiccup [c]
+  (into [:blockquote] (map pandoc-block->hiccup c)))
+
+(defn pandoc-codeblock->hiccup [[attr code]]
+  (let [attributes (-> attr
+                       (update 2 (partial map (fn [[k v]] [(str "data-" k) v])))
+                       (pandoc-attr->hiccup))]
+    (cond-> [:pre]
+      (not (empty? attributes)) (conj attributes)
+      true (conj [:code code]))))
+
+;; See: https://hackage.haskell.org/package/pandoc-types-1.23.1/docs/Text-Pandoc-Definition.html#t:Block
+(defn pandoc-block->hiccup [{:keys [t c] :as block}]
+  (case (keyword t)
+    :Para (pandoc-para->hiccup c)
+    :Header (pandoc-header->hiccup c)
+    :BlockQuote (pandoc-blockquote->hiccup c)
+    :CodeBlock (pandoc-codeblock->hiccup c)))
 
 (defn pandoc->hiccup [{:keys [blocks]}]
   (map pandoc-block->hiccup blocks))

--- a/src/teodorlu/pandoc2hiccup.clj
+++ b/src/teodorlu/pandoc2hiccup.clj
@@ -28,7 +28,12 @@
     ;; however assumes the pandoc default css file to be included. I'm opting to
     ;; inline this instead.
     ;; See: https://pandoc.org/chunkedhtml-demo/8.12-inline-formatting.html#small-caps
-    :SmallCaps (wrap-inline [:span {:style {:font-variant "small-caps"}}] c)))
+    :SmallCaps (wrap-inline [:span {:style {:font-variant "small-caps"}}] c)
+    :Quoted (let [[{quote-type :t} content] c
+                  [open close] (case (keyword quote-type)
+                                 :SingleQuote ["‘" "’"]
+                                 :DoubleQuote ["“" "”"])]
+              (concat [open] (wrap-inline () content) [close]))))
 
 (defn pandoc-para->hiccup [c]
   (wrap-inline [:p] c))

--- a/test/teodorlu/pandoc2hiccup_test.clj
+++ b/test/teodorlu/pandoc2hiccup_test.clj
@@ -105,15 +105,15 @@
           {:t "CodeBlock", :c [["id", ["class1", "class2"], [["key", "value"]]], "code here"]}))))
 
 (deftest orderedlist-test
-  (is (= [:ol [:li "Item 1"] [:li "Item 2"]]
+  (is (= '[:ol {:type "1"} [:li ("Item 1")] [:li ("Item 2")]]
          (pandoc2hiccup/pandoc-block->hiccup
           {:t "OrderedList", :c [[1, "Decimal", "Period"] [[{:t "Plain", :c [{:t "Str", :c "Item 1"}]}] [{:t "Plain", :c [{:t "Str", :c "Item 2"}]}]]]}))))
 
 (deftest orderedlist-rich-test
-  (is (= [:ol {:type "i"} [:li "First Item"] [:li [:em "Second"] " Item"]]
+  (is (= '[:ol {:type "i"} [:li ("First Item")] [:li ([:em "Second"] " Item")]]
          (pandoc2hiccup/pandoc-block->hiccup
           {:t "OrderedList",
-           :c [[1, "OneRoman", "Period"],
+           :c [[1, "LowerRoman", "Period"],
                [[{:t "Plain", :c [{:t "Str", :c "First Item"}]}],
                 [{:t "Plain", :c [{:t "Emph", :c [{:t "Str", :c "Second"}]} {:t "Str", :c " Item"}]}]]]}))))
 

--- a/test/teodorlu/pandoc2hiccup_test.clj
+++ b/test/teodorlu/pandoc2hiccup_test.clj
@@ -25,7 +25,7 @@
           {:t "Strong", :c [{:t "Str", :c "there"}]}))))
 
 (deftest strikeout-test
-  (is (= [:s "struckout"]
+  (is (= [:del "struckout"]
          (pandoc2hiccup/pandoc-inline->hiccup
           {:t "Strikeout", :c [{:t "Str", :c "struckout"}]}))))
 

--- a/test/teodorlu/pandoc2hiccup_test.clj
+++ b/test/teodorlu/pandoc2hiccup_test.clj
@@ -4,17 +4,54 @@
    [teodorlu.pandoc2hiccup :as pandoc2hiccup]
    [babashka.cli]))
 
+;; Inline Element Tests
+
 (deftest space-test
-  (is (= " " (pandoc2hiccup/pandoc-block->hiccup {:t "Space"}))))
+  (is (= " " (pandoc2hiccup/pandoc-inline->hiccup {:t "Space"}))))
 
 (deftest string-test
   (is (= "there"
-         (pandoc2hiccup/pandoc-block->hiccup {:t "Str", :c "there"}))))
+         (pandoc2hiccup/pandoc-inline->hiccup
+          {:t "Str", :c "there"}))))
 
 (deftest emph-test
   (is (= [:em "there"]
-         (pandoc2hiccup/pandoc-block->hiccup
+         (pandoc2hiccup/pandoc-inline->hiccup
           {:t "Emph", :c [{:t "Str", :c "there"}]}))))
+
+(deftest strong-test
+  (is (= [:strong "there"]
+         (pandoc2hiccup/pandoc-inline->hiccup
+          {:t "Strong", :c [{:t "Str", :c "there"}]}))))
+
+(deftest strikeout-test
+  (is (= [:s "struckout"]
+         (pandoc2hiccup/pandoc-inline->hiccup
+          {:t "Strikeout", :c [{:t "Str", :c "struckout"}]}))))
+
+(deftest superscript-test
+  (is (= [:sup "super"]
+         (pandoc2hiccup/pandoc-inline->hiccup
+          {:t "Superscript", :c [{:t "Str", :c "super"}]}))))
+
+(deftest subscript-test
+  (is (= [:sub "sub"]
+         (pandoc2hiccup/pandoc-inline->hiccup
+          {:t "Subscript", :c [{:t "Str", :c "sub"}]}))))
+
+(deftest smallcaps-test
+  (is (= [:span {:style {:font-variant "small-caps"}} "smallcaps"]
+         (pandoc2hiccup/pandoc-inline->hiccup
+          {:t "SmallCaps", :c [{:t "Str", :c "smallcaps"}]}))))
+
+(deftest quoted-test
+  (is (= [:q "quoted"]
+         (pandoc2hiccup/pandoc-inline->hiccup
+          {:t "Quoted", :c [["DoubleQuote"] [{:t "Str", :c "quoted"}]]}))))
+
+
+
+;; Block Element Tests
 
 (deftest para-test
   (is (= [:p "hi," " " [:em "there"] "!"]
@@ -25,6 +62,142 @@
             {:t "Space"}
             {:t "Emph", :c [{:t "Str", :c "there"}]}
             {:t "Str", :c "!"}]}))))
+
+(deftest header-test-level-1
+  (is (= [:h1 "Header text"]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "Header", :c [1 ["",[],[]] [{:t "Str", :c "Header text"}]]}))))
+
+(deftest header-test-level-2-with-attributes
+  (is (= [:h2 {:id "sec-1" :class ["title"]} "Subheader text"]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "Header", :c [2 ["sec-1",["title"],[]] [{:t "Str", :c "Subheader text"}]]}))))
+
+(deftest header-test-level-3-nested-inlines
+  (is (= [:h3 "Nested" " " [:em "inlines"] " " "here"]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "Header", :c [3 ["",[],[]] [{:t "Str", :c "Nested"} {:t "Space"} {:t "Emph", :c [{:t "Str", :c "inlines"}]} {:t "Space"} {:t "Str", :c "here"}]]}))))
+
+(deftest blockquote-test
+  (is (= [:blockquote [:p "Quote text"]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "BlockQuote", :c [{:t "Para", :c [{:t "Str", :c "Quote text"}]}]}))))
+
+(deftest codeblock-test
+  (is (= [:pre [:code "code here"]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "CodeBlock", :c [["", [], []] "code here"]}))))
+
+(deftest codeblock-test-with-attr
+  (is (= [:pre {:id "id", :class ["class1" "class2"], "data-key" "value"}
+          [:code "code here"]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "CodeBlock", :c [["id", ["class1", "class2"], [["key", "value"]]], "code here"]}))))
+
+(deftest orderedlist-test
+  (is (= [:ol [:li "Item 1"] [:li "Item 2"]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "OrderedList", :c [[1, "Decimal", "Period"] [[{:t "Plain", :c [{:t "Str", :c "Item 1"}]}] [{:t "Plain", :c [{:t "Str", :c "Item 2"}]}]]]}))))
+
+(deftest orderedlist-rich-test
+  (is (= [:ol {:type "i"} [:li "First Item"] [:li [:em "Second"] " Item"]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "OrderedList",
+           :c [[1, "OneRoman", "Period"],
+               [[{:t "Plain", :c [{:t "Str", :c "First Item"}]}],
+                [{:t "Plain", :c [{:t "Emph", :c [{:t "Str", :c "Second"}]} {:t "Str", :c " Item"}]}]]]}))))
+
+(deftest bulletlist-test
+  (is (= [:ul [:li "Item 1"] [:li "Item 2"]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "BulletList", :c [[{:t "Plain", :c [{:t "Str", :c "Item 1"}]}] [{:t "Plain", :c [{:t "Str", :c "Item 2"}]}]]}))))
+
+(deftest nested-list-test
+  (is (= [:ul [:li "Item 1" [:ul [:li "Subitem 1"] [:li "Subitem 2"]]] [:li "Item 2"]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "BulletList",
+           :c [[{:t "Plain", :c [{:t "Str", :c "Item 1"}]},
+                {:t "BulletList",
+                 :c [[{:t "Plain", :c [{:t "Str", :c "Subitem 1"}]}],
+                     [{:t "Plain", :c [{:t "Str", :c "Subitem 2"}]}]]}],
+               [{:t "Plain", :c [{:t "Str", :c "Item 2"}]}]]}))))
+
+(deftest definitionlist-test
+  (is (= [:dl [:dt "Term"] [:dd [:p "Definition"]]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "DefinitionList", :c [[{:t "Str", :c "Term"}] [[{:t "Para", :c [{:t "Str", :c "Definition"}]}]]]}))))
+
+(deftest lineblock-test
+  (is (= [:pre "Line 1\nLine 2"]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "LineBlock", :c [[{:t "Str", :c "Line 1"}] [{:t "Str", :c "Line 2"}]]}))))
+
+(deftest lineblock-test-multiple
+  (is (= [:pre "Line 1\nLine 2\nLine 3"]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "LineBlock", :c [[{:t "Str", :c "Line 1"}] [{:t "Str", :c "Line 2"}] [{:t "Str", :c "Line 3"}]]}))))
+
+(deftest rawblock-test
+  (is (= [:div {:dangerouslySetInnerHTML {:__html "<div>raw HTML</div>"}}]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "RawBlock", :c ["html" "<div>raw HTML</div>"]}))))
+
+(deftest horizontalrule-test
+  (is (= [:hr]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "HorizontalRule"}))))
+
+(deftest table-test
+  (is (= [:table [:caption "Caption"] [:thead [:tr [:th "Header"]]] [:tbody [:tr [:td "Cell"]]]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "Table", :c [["", [], []], ["Caption", []], [], [:thead [:tr [:th "Header"]]], [[:tbody [:tr [:td "Cell"]]]], [:tfoot]]}))))
+
+(deftest table-complex-test
+  (is (= [:table
+          [:caption "Complex Table"]
+          [:thead [:tr [:th "Header1"] [:th "Header2"]]]
+          [:tbody
+           [:tr [:td "Row1, Col1"] [:td "Row1, Col2"]]
+           [:tr [:td "Row2, Col1"] [:td "Row2, Col2"]]]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "Table",
+           :c [["", [], []],
+               ["Complex Table", []],
+               [], ; column alignments
+               [[{:t "Str", :c "Header1"}] [{:t "Str", :c "Header2"}]], ; headers
+               [[[{:t "Str", :c "Row1, Col1"}] [{:t "Str", :c "Row1, Col2"}]],
+                [[{:t "Str", :c "Row2, Col1"}] [{:t "Str", :c "Row2, Col2"}]]], ; rows
+               []]}))))
+
+(deftest figure-test
+  (is (= [:figure [:figcaption "Caption"] [:p "Content"]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "Figure", :c [["", [], []], ["Caption", []], [{:t "Para", :c [{:t "Str", :c "Content"}]}]]}))))
+
+(deftest div-test
+  (is (= [:div {:class "container"} [:p "Content"]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "Div", :c [["", ["container"], []], [{:t "Para", :c [{:t "Str", :c "Content"}]}]]}))))
+
+;; Document Tests
+
+(deftest document-with-meta-test
+  (is (= '([:meta {:title "Document Title"}]
+           [:p "Content"])
+         (pandoc2hiccup/pandoc->hiccup
+          {:pandoc-api-version [1 23 1],
+           :meta {:title {:t "MetaInlines", :c [{:t "Str", :c "Document Title"}]}},
+           :blocks [{:t "Para", :c [{:t "Str", :c "Content"}]}]}))))
+
+(deftest complex-nested-test
+  (is (= [:div [:p "Complex" [:strong "nested"] "content"]]
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "Div",
+           :c [["", [], []],
+               [{:t "Para",
+                 :c [{:t "Str", :c "Complex"},
+                     {:t "Strong", :c [{:t "Str", :c "nested"}]},
+                     {:t "Str", :c "content"}]}]]}))))
 
 (deftest hiccup-test
   (is (= '([:p "hei"] [:p "oslo" " " "clojure"])

--- a/test/teodorlu/pandoc2hiccup_test.clj
+++ b/test/teodorlu/pandoc2hiccup_test.clj
@@ -44,10 +44,15 @@
          (pandoc2hiccup/pandoc-inline->hiccup
           {:t "SmallCaps", :c [{:t "Str", :c "smallcaps"}]}))))
 
-(deftest quoted-test
-  (is (= [:q "quoted"]
+(deftest quoted-single-test
+  (is (= '("‘" "single quote" "’")
          (pandoc2hiccup/pandoc-inline->hiccup
-          {:t "Quoted", :c [["DoubleQuote"] [{:t "Str", :c "quoted"}]]}))))
+          {:t "Quoted", :c [{:t "SingleQuote"} [{:t "Str", :c "single quote"}]]}))))
+
+(deftest quoted-double-test
+  (is (= '("“" "double quote" "”")
+         (pandoc2hiccup/pandoc-inline->hiccup
+          {:t "Quoted", :c [{:t "DoubleQuote"} [{:t "Str", :c "double quote"}]]}))))
 
 
 

--- a/test/teodorlu/pandoc2hiccup_test.clj
+++ b/test/teodorlu/pandoc2hiccup_test.clj
@@ -58,6 +58,11 @@
 
 ;; Block Element Tests
 
+(deftest plain-test
+  (is (= '("Plain" " " "text")
+         (pandoc2hiccup/pandoc-block->hiccup
+          {:t "Plain", :c [{:t "Str", :c "Plain"} {:t "Space"} {:t "Str", :c "text"}]}))))
+
 (deftest para-test
   (is (= [:p "hi," " " [:em "there"] "!"]
          (pandoc2hiccup/pandoc-block->hiccup

--- a/test/teodorlu/pandoc2hiccup_test.clj
+++ b/test/teodorlu/pandoc2hiccup_test.clj
@@ -118,12 +118,12 @@
                 [{:t "Plain", :c [{:t "Emph", :c [{:t "Str", :c "Second"}]} {:t "Str", :c " Item"}]}]]]}))))
 
 (deftest bulletlist-test
-  (is (= [:ul [:li "Item 1"] [:li "Item 2"]]
+  (is (= '[:ul [:li ("Item 1")] [:li ("Item 2")]]
          (pandoc2hiccup/pandoc-block->hiccup
           {:t "BulletList", :c [[{:t "Plain", :c [{:t "Str", :c "Item 1"}]}] [{:t "Plain", :c [{:t "Str", :c "Item 2"}]}]]}))))
 
 (deftest nested-list-test
-  (is (= [:ul [:li "Item 1" [:ul [:li "Subitem 1"] [:li "Subitem 2"]]] [:li "Item 2"]]
+  (is (= '[:ul [:li ("Item 1") [:ul [:li ("Subitem 1")] [:li ("Subitem 2")]]] [:li ("Item 2")]]
          (pandoc2hiccup/pandoc-block->hiccup
           {:t "BulletList",
            :c [[{:t "Plain", :c [{:t "Str", :c "Item 1"}]},


### PR DESCRIPTION
This commit is too big.

The commit adds tests for most of the data types of Pandoc (with help from an LLM). The plan is to use the tests to drive the development.

The commit separates inline and block, which are separate datatypes in the haskell definition.

The commit adds support for most of the inline constructs and a few more block constructs.