### PR TITLE
Run tests in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,9 @@ jobs:
       with:
         clj-kondo: 2024.03.13
 
+    - name: Install dependencies
+      run: clj -e :download-deps
+
     - name: "Clj-kondo: show version"
       run: clj-kondo --version
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,9 +12,6 @@ jobs:
       with:
         clj-kondo: 2024.03.13
 
-    - name: Install dependencies
-      run: clj -A:ci -e :download-deps
-
     - name: "Clj-kondo: show version"
       run: clj-kondo --version
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Install Clojure & Clj-kondo
+    - name: Install Clj-kondo
       uses: DeLaGuardo/setup-clojure@12.5
       with:
         clj-kondo: 2024.03.13

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         clj-kondo: 2024.03.13
 
     - name: Install dependencies
-      run: clj -e :download-deps
+      run: clj -A:ci -e :download-deps
 
     - name: "Clj-kondo: show version"
       run: clj-kondo --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         cli: 1.11.3.1463
 
     - name: Install dependencies
-      run: clj -A:ci -e :download-deps
+      run: clojure -A:ci -e :download-deps
 
     - name: "Kaocha: run tests"
       run: bin/kaocha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,10 +7,16 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Prepare java
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+
     - name: Install Clojure & Clj-kondo
       uses: DeLaGuardo/setup-clojure@12.5
       with:
-        clj-kondo: 2024.03.13
+        cli: 1.11.3.1463
 
     - name: "Kaocha: run tests"
       run: bin/kaocha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Static analysis with clj-kondo
+name: Run tests with Kaocha
 on: push
 jobs:
   lint:
@@ -12,8 +12,5 @@ jobs:
       with:
         clj-kondo: 2024.03.13
 
-    - name: "Clj-kondo: show version"
-      run: clj-kondo --version
-
-    - name: "Clj-kondo: lint"
-      run: clj-kondo --fail-level error --lint src test
+    - name: "Kaocha: run tests"
+      run: bin/kaocha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,8 @@ jobs:
       with:
         cli: 1.11.3.1463
 
+    - name: Install dependencies
+      run: clj -A:ci -e :download-deps
+
     - name: "Kaocha: run tests"
       run: bin/kaocha

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         distribution: 'temurin'
         java-version: '21'
 
-    - name: Install Clojure & Clj-kondo
+    - name: Install Clojure
       uses: DeLaGuardo/setup-clojure@12.5
       with:
         cli: 1.11.3.1463

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Run tests with Kaocha
 on: push
 jobs:
-  lint:
+  run-tests:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/deps.edn
+++ b/deps.edn
@@ -12,4 +12,6 @@
            :main-opts ["-m" "kaocha.runner"]}
   :dev {:extra-paths ["test" "dev"]
         :extra-deps {io.github.tonsky/clj-reload {:mvn/version "0.7.0"}
-                     lambdaisland/kaocha {:mvn/version "1.90.1383"}}}}}
+                     lambdaisland/kaocha {:mvn/version "1.90.1383"}}}
+  :ci {:extra-deps {lambdaisland/kaocha {:mvn/version "1.90.1383"}}
+       :extra-paths ["test"]}}}


### PR DESCRIPTION
@larstvei du kan gjerne ta en titt på endringene her også.

Målet med denne og #3 er å få en sånn grønn greie ved siden av commitene som vi kan stole på. I denne PR-en setter jeg opp testene til å kjøre. Det gjør at vi får 🔴 hvis linter eller tester feiler, og 🟢 når alt ser OK ut.

Jeg har splittet opp i to forskjellige workflows, `lint` og `test`. Da kjører de uavhengig av hverandre.